### PR TITLE
Remove org_deploy_enabled field from manifest

### DIFF
--- a/manifest/manifest.js
+++ b/manifest/manifest.js
@@ -21,7 +21,6 @@ module.exports = Manifest({
     interactivity: {
       is_enabled: true,
     },
-    org_deploy_enabled: false,
   },
   tokenRotationEnabled: false,
 });


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

Remove the `org_deploy_enabled` field from manifest so the CLI will auto-populate it. Currently, it being set to `false` is throwing errors and invalidating the manifest.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
