### PR TITLE
Fix dependabot dependency issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "~16.0.3"
       },
       "devDependencies": {
-        "eslint": "~8.23.0",
+        "eslint": "~8.24.0",
         "eslint-config-airbnb-base": "~15.0.0",
         "eslint-plugin-import": "~2.26.0"
       }
@@ -1140,13 +1140,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.23.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.2",
-        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/config-array": "^0.10.5",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
@@ -4382,13 +4382,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.23.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.2",
-        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/config-array": "^0.10.5",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@slack/bolt": "next-gen",
         "@slack/deno-slack-sdk": "^1.1.2",
-        "dotenv": "~16.0.2"
+        "dotenv": "~16.0.3"
       },
       "devDependencies": {
         "eslint": "~8.23.0",
@@ -19,10 +19,24 @@
         "eslint-plugin-import": "~2.26.0"
       }
     },
+    "node_modules/@deno/shim-deno": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.10.0.tgz",
+      "integrity": "sha512-E7rQ0Hk33V45xQXKEnCxizdSP5C+hhqw1H3xWXsct3kYFWgG93B5gN3LKlyvcxbckt8d67jVa6s+y5duRYawvg==",
+      "dependencies": {
+        "@deno/shim-deno-test": "^0.3.2",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/@deno/shim-deno-test": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.3.3.tgz",
+      "integrity": "sha512-Ge0Tnl7zZY0VvEfgsyLhjid8DzI1d0La0dgm+3m0/A8gZXgp5xwlyIyue5e4SCUuVB/3AH/0lun9LcJhhTwmbg=="
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -43,9 +57,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -121,16 +135,16 @@
       }
     },
     "node_modules/@slack/bolt": {
-      "version": "4.0.0-nextGen.2",
-      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.0.0-nextGen.2.tgz",
-      "integrity": "sha512-aenyxrYo2vrshN3sn5v1uuy9j7LuJKwFj1ofWHnSMJbH+PwSqzxDJJiXNju+7rRMuZs6S8YFt9WH+SdYL7piWw==",
+      "version": "4.0.0-nextGen.6",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.0.0-nextGen.6.tgz",
+      "integrity": "sha512-mQyrLXd8OBYhJm9YTJi4OG7fL5XGsgTn1wbc25vTBONGkUS01lNk2rlryI2U7JuTv1MXd9GQju1vn8UoTqZpmw==",
       "dependencies": {
         "@slack/deno-slack-sdk": "^1.0.0",
         "@slack/logger": "^3.0.0",
         "@slack/oauth": "^2.5.1",
         "@slack/socket-mode": "^1.3.0",
         "@slack/types": "^2.7.0",
-        "@slack/web-api": "^6.7.1",
+        "@slack/web-api": "6.7.2-nextGen.1",
         "@types/express": "^4.16.1",
         "@types/node": "18.7.15",
         "@types/promise.allsettled": "^1.0.3",
@@ -148,6 +162,7 @@
         "slack-cli-get-hooks": "src/cli/get-hooks.js",
         "slack-cli-get-manifest": "src/cli/get-manifest.js",
         "slack-cli-hook-utils": "src/cli/hook-utils/manifest.js",
+        "slack-cli-hook-utils-get-manifest-data": "src/cli/hook-utils/get-manifest-data.js",
         "slack-cli-start": "src/cli/start.js"
       },
       "engines": {
@@ -156,9 +171,17 @@
       }
     },
     "node_modules/@slack/deno-slack-sdk": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@slack/deno-slack-sdk/-/deno-slack-sdk-1.1.2.tgz",
-      "integrity": "sha512-vkaOQKYO6eGZgIhA8MD9j5HdDDWSIL/Gs6HOMA29MwoDWzG1432teFm56mqxnnKCvU6idmIBey45af8K8Gf2pg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@slack/deno-slack-sdk/-/deno-slack-sdk-1.2.0.tgz",
+      "integrity": "sha512-8jgdl8BmccDj35OChtDf1yK3TBqSZ/pzCT/+b6vI+tRlUWkqe/hH9ZFHyyLsYl4QtjmZpWBru0oMG2npaywtzw==",
+      "dependencies": {
+        "@deno/shim-deno": "~0.10.0",
+        "node-fetch": "2.6.7"
+      },
+      "engines": {
+        "node": ">=14.20.1",
+        "npm": ">=6.14.15"
+      }
     },
     "node_modules/@slack/logger": {
       "version": "3.0.0",
@@ -189,6 +212,70 @@
         "npm": ">=6.12.0"
       }
     },
+    "node_modules/@slack/oauth/node_modules/@slack/web-api": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2.tgz",
+      "integrity": "sha512-qgWMxdy1A2uNvhETfRl349UjTEvnUzHl947Ly5c+lqOrXJIwsG12szL4tD3WrRlTuxCijDemF3FjtUNz18YAxg==",
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.0.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^0.27.2",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "2.2.0",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/oauth/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@slack/oauth/node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@slack/oauth/node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@slack/oauth/node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/@slack/socket-mode": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-1.3.1.tgz",
@@ -210,6 +297,70 @@
         "npm": ">=6.12.0"
       }
     },
+    "node_modules/@slack/socket-mode/node_modules/@slack/web-api": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2.tgz",
+      "integrity": "sha512-qgWMxdy1A2uNvhETfRl349UjTEvnUzHl947Ly5c+lqOrXJIwsG12szL4tD3WrRlTuxCijDemF3FjtUNz18YAxg==",
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.0.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^0.27.2",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "2.2.0",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/socket-mode/node_modules/@slack/web-api/node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@slack/socket-mode/node_modules/@slack/web-api/node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/@slack/socket-mode/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@slack/socket-mode/node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@slack/types": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.7.0.tgz",
@@ -220,9 +371,9 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2.tgz",
-      "integrity": "sha512-qgWMxdy1A2uNvhETfRl349UjTEvnUzHl947Ly5c+lqOrXJIwsG12szL4tD3WrRlTuxCijDemF3FjtUNz18YAxg==",
+      "version": "6.7.2-nextGen.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2-nextGen.1.tgz",
+      "integrity": "sha512-7F3P7l23nIadgioeGe/Hwfnttqejz5XMvQuzkPE2A903tUIr6VGin2UMoXiLPmCoQ1UZiPU8/0bHmFJhN+vmdw==",
       "dependencies": {
         "@slack/logger": "^3.0.0",
         "@slack/types": "^2.0.0",
@@ -301,9 +452,9 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -312,9 +463,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.30",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
-      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
+      "version": "4.17.31",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
+      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -858,9 +1009,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
         "node": ">=12"
       }
@@ -887,30 +1038,31 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
+      "integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
+        "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
+        "is-callable": "^1.2.6",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
+        "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
+        "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
@@ -988,12 +1140,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.1",
+        "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -1012,7 +1164,6 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -1021,6 +1172,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -1486,9 +1638,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
@@ -1566,12 +1718,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
-    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -1581,9 +1727,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -1883,9 +2029,9 @@
       }
     },
     "node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2076,8 +2222,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/iterate-iterator": {
       "version": "1.0.2",
@@ -2098,6 +2243,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -2360,6 +2511,25 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-inspect": {
@@ -2861,6 +3031,19 @@
         }
       ]
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3100,6 +3283,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -3203,11 +3391,24 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3282,10 +3483,24 @@
     }
   },
   "dependencies": {
+    "@deno/shim-deno": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.10.0.tgz",
+      "integrity": "sha512-E7rQ0Hk33V45xQXKEnCxizdSP5C+hhqw1H3xWXsct3kYFWgG93B5gN3LKlyvcxbckt8d67jVa6s+y5duRYawvg==",
+      "requires": {
+        "@deno/shim-deno-test": "^0.3.2",
+        "which": "^2.0.2"
+      }
+    },
+    "@deno/shim-deno-test": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.3.3.tgz",
+      "integrity": "sha512-Ge0Tnl7zZY0VvEfgsyLhjid8DzI1d0La0dgm+3m0/A8gZXgp5xwlyIyue5e4SCUuVB/3AH/0lun9LcJhhTwmbg=="
+    },
     "@eslint/eslintrc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -3300,9 +3515,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -3355,16 +3570,16 @@
       }
     },
     "@slack/bolt": {
-      "version": "4.0.0-nextGen.2",
-      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.0.0-nextGen.2.tgz",
-      "integrity": "sha512-aenyxrYo2vrshN3sn5v1uuy9j7LuJKwFj1ofWHnSMJbH+PwSqzxDJJiXNju+7rRMuZs6S8YFt9WH+SdYL7piWw==",
+      "version": "4.0.0-nextGen.6",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.0.0-nextGen.6.tgz",
+      "integrity": "sha512-mQyrLXd8OBYhJm9YTJi4OG7fL5XGsgTn1wbc25vTBONGkUS01lNk2rlryI2U7JuTv1MXd9GQju1vn8UoTqZpmw==",
       "requires": {
         "@slack/deno-slack-sdk": "^1.0.0",
         "@slack/logger": "^3.0.0",
         "@slack/oauth": "^2.5.1",
         "@slack/socket-mode": "^1.3.0",
         "@slack/types": "^2.7.0",
-        "@slack/web-api": "^6.7.1",
+        "@slack/web-api": "6.7.2-nextGen.1",
         "@types/express": "^4.16.1",
         "@types/node": "18.7.15",
         "@types/promise.allsettled": "^1.0.3",
@@ -3380,9 +3595,13 @@
       }
     },
     "@slack/deno-slack-sdk": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@slack/deno-slack-sdk/-/deno-slack-sdk-1.1.2.tgz",
-      "integrity": "sha512-vkaOQKYO6eGZgIhA8MD9j5HdDDWSIL/Gs6HOMA29MwoDWzG1432teFm56mqxnnKCvU6idmIBey45af8K8Gf2pg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@slack/deno-slack-sdk/-/deno-slack-sdk-1.2.0.tgz",
+      "integrity": "sha512-8jgdl8BmccDj35OChtDf1yK3TBqSZ/pzCT/+b6vI+tRlUWkqe/hH9ZFHyyLsYl4QtjmZpWBru0oMG2npaywtzw==",
+      "requires": {
+        "@deno/shim-deno": "~0.10.0",
+        "node-fetch": "2.6.7"
+      }
     },
     "@slack/logger": {
       "version": "3.0.0",
@@ -3403,6 +3622,63 @@
         "@types/node": ">=12",
         "jsonwebtoken": "^8.5.1",
         "lodash.isstring": "^4.0.1"
+      },
+      "dependencies": {
+        "@slack/web-api": {
+          "version": "6.7.2",
+          "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2.tgz",
+          "integrity": "sha512-qgWMxdy1A2uNvhETfRl349UjTEvnUzHl947Ly5c+lqOrXJIwsG12szL4tD3WrRlTuxCijDemF3FjtUNz18YAxg==",
+          "requires": {
+            "@slack/logger": "^3.0.0",
+            "@slack/types": "^2.0.0",
+            "@types/is-stream": "^1.1.0",
+            "@types/node": ">=12.0.0",
+            "axios": "^0.27.2",
+            "eventemitter3": "^3.1.0",
+            "form-data": "^2.5.0",
+            "is-electron": "2.2.0",
+            "is-stream": "^1.1.0",
+            "p-queue": "^6.6.1",
+            "p-retry": "^4.0.0"
+          }
+        },
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          },
+          "dependencies": {
+            "form-data": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+              "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+              }
+            }
+          }
+        },
+        "p-queue": {
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+          "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+          "requires": {
+            "eventemitter3": "^4.0.4",
+            "p-timeout": "^3.2.0"
+          },
+          "dependencies": {
+            "eventemitter3": {
+              "version": "4.0.7",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+              "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+            }
+          }
+        }
       }
     },
     "@slack/socket-mode": {
@@ -3420,6 +3696,65 @@
         "p-cancelable": "^1.1.0",
         "p-queue": "^2.4.2",
         "ws": "^7.5.3"
+      },
+      "dependencies": {
+        "@slack/web-api": {
+          "version": "6.7.2",
+          "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2.tgz",
+          "integrity": "sha512-qgWMxdy1A2uNvhETfRl349UjTEvnUzHl947Ly5c+lqOrXJIwsG12szL4tD3WrRlTuxCijDemF3FjtUNz18YAxg==",
+          "requires": {
+            "@slack/logger": "^3.0.0",
+            "@slack/types": "^2.0.0",
+            "@types/is-stream": "^1.1.0",
+            "@types/node": ">=12.0.0",
+            "axios": "^0.27.2",
+            "eventemitter3": "^3.1.0",
+            "form-data": "^2.5.0",
+            "is-electron": "2.2.0",
+            "is-stream": "^1.1.0",
+            "p-queue": "^6.6.1",
+            "p-retry": "^4.0.0"
+          },
+          "dependencies": {
+            "p-queue": {
+              "version": "6.6.2",
+              "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+              "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+              "requires": {
+                "eventemitter3": "^4.0.4",
+                "p-timeout": "^3.2.0"
+              },
+              "dependencies": {
+                "eventemitter3": {
+                  "version": "4.0.7",
+                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+                  "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+                }
+              }
+            }
+          }
+        },
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          },
+          "dependencies": {
+            "form-data": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+              "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+              }
+            }
+          }
+        }
       }
     },
     "@slack/types": {
@@ -3428,9 +3763,9 @@
       "integrity": "sha512-QUrHBilZeWyXAuHfEbSnzBwvFm4u/75LHKRKu8xRUnGNt35Amz8y9YQwb6voU1S5FmTYxMNAL+ZbAPTor4aRdw=="
     },
     "@slack/web-api": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2.tgz",
-      "integrity": "sha512-qgWMxdy1A2uNvhETfRl349UjTEvnUzHl947Ly5c+lqOrXJIwsG12szL4tD3WrRlTuxCijDemF3FjtUNz18YAxg==",
+      "version": "6.7.2-nextGen.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2-nextGen.1.tgz",
+      "integrity": "sha512-7F3P7l23nIadgioeGe/Hwfnttqejz5XMvQuzkPE2A903tUIr6VGin2UMoXiLPmCoQ1UZiPU8/0bHmFJhN+vmdw==",
       "requires": {
         "@slack/logger": "^3.0.0",
         "@slack/types": "^2.0.0",
@@ -3502,9 +3837,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -3513,9 +3848,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.30",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
-      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
+      "version": "4.17.31",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
+      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3943,9 +4278,9 @@
       }
     },
     "dotenv": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -3966,30 +4301,31 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
     "es-abstract": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
+      "integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
+        "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
+        "is-callable": "^1.2.6",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
+        "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
+        "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
@@ -4046,12 +4382,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.1",
+        "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -4070,7 +4406,6 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -4079,6 +4414,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -4459,9 +4795,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "form-data": {
       "version": "2.5.1",
@@ -4510,21 +4846,15 @@
         "functions-have-names": "^1.2.2"
       }
     },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
-    },
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
     "get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -4731,9 +5061,9 @@
       }
     },
     "is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
       "version": "2.10.0",
@@ -4855,8 +5185,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "iterate-iterator": {
       "version": "1.0.2",
@@ -4871,6 +5200,12 @@
         "es-get-iterator": "^1.0.2",
         "iterate-iterator": "^1.0.1"
       }
+    },
+    "js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -5084,6 +5419,14 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -5403,6 +5746,16 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5589,6 +5942,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -5665,11 +6023,24 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@slack/bolt": "next-gen",
-        "@slack/deno-slack-sdk": "^1.1.2",
+        "@slack/deno-slack-sdk": "^1.2.0",
         "dotenv": "~16.0.3"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,33 +10,19 @@
       "license": "MIT",
       "dependencies": {
         "@slack/bolt": "next-gen",
-        "@slack/deno-slack-sdk": "^1.2.0",
-        "dotenv": "~16.0.3"
+        "@slack/deno-slack-sdk": "^1.1.2",
+        "dotenv": "~16.0.2"
       },
       "devDependencies": {
-        "eslint": "~8.24.0",
+        "eslint": "~8.23.0",
         "eslint-config-airbnb-base": "~15.0.0",
         "eslint-plugin-import": "~2.26.0"
       }
     },
-    "node_modules/@deno/shim-deno": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.10.0.tgz",
-      "integrity": "sha512-E7rQ0Hk33V45xQXKEnCxizdSP5C+hhqw1H3xWXsct3kYFWgG93B5gN3LKlyvcxbckt8d67jVa6s+y5duRYawvg==",
-      "dependencies": {
-        "@deno/shim-deno-test": "^0.3.2",
-        "which": "^2.0.2"
-      }
-    },
-    "node_modules/@deno/shim-deno-test": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.3.3.tgz",
-      "integrity": "sha512-Ge0Tnl7zZY0VvEfgsyLhjid8DzI1d0La0dgm+3m0/A8gZXgp5xwlyIyue5e4SCUuVB/3AH/0lun9LcJhhTwmbg=="
-    },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
+      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -57,9 +43,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -135,16 +121,16 @@
       }
     },
     "node_modules/@slack/bolt": {
-      "version": "4.0.0-nextGen.6",
-      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.0.0-nextGen.6.tgz",
-      "integrity": "sha512-mQyrLXd8OBYhJm9YTJi4OG7fL5XGsgTn1wbc25vTBONGkUS01lNk2rlryI2U7JuTv1MXd9GQju1vn8UoTqZpmw==",
+      "version": "4.0.0-nextGen.2",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.0.0-nextGen.2.tgz",
+      "integrity": "sha512-aenyxrYo2vrshN3sn5v1uuy9j7LuJKwFj1ofWHnSMJbH+PwSqzxDJJiXNju+7rRMuZs6S8YFt9WH+SdYL7piWw==",
       "dependencies": {
         "@slack/deno-slack-sdk": "^1.0.0",
         "@slack/logger": "^3.0.0",
         "@slack/oauth": "^2.5.1",
         "@slack/socket-mode": "^1.3.0",
         "@slack/types": "^2.7.0",
-        "@slack/web-api": "6.7.2-nextGen.1",
+        "@slack/web-api": "^6.7.1",
         "@types/express": "^4.16.1",
         "@types/node": "18.7.15",
         "@types/promise.allsettled": "^1.0.3",
@@ -162,7 +148,6 @@
         "slack-cli-get-hooks": "src/cli/get-hooks.js",
         "slack-cli-get-manifest": "src/cli/get-manifest.js",
         "slack-cli-hook-utils": "src/cli/hook-utils/manifest.js",
-        "slack-cli-hook-utils-get-manifest-data": "src/cli/hook-utils/get-manifest-data.js",
         "slack-cli-start": "src/cli/start.js"
       },
       "engines": {
@@ -170,82 +155,10 @@
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/@slack/bolt/node_modules/@slack/web-api": {
-      "version": "6.7.2-nextGen.1",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2-nextGen.1.tgz",
-      "integrity": "sha512-7F3P7l23nIadgioeGe/Hwfnttqejz5XMvQuzkPE2A903tUIr6VGin2UMoXiLPmCoQ1UZiPU8/0bHmFJhN+vmdw==",
-      "dependencies": {
-        "@slack/logger": "^3.0.0",
-        "@slack/types": "^2.0.0",
-        "@types/is-stream": "^1.1.0",
-        "@types/node": ">=12.0.0",
-        "axios": "^0.27.2",
-        "eventemitter3": "^3.1.0",
-        "form-data": "^2.5.0",
-        "is-electron": "2.2.0",
-        "is-stream": "^1.1.0",
-        "p-queue": "^6.6.1",
-        "p-retry": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 12.13.0",
-        "npm": ">= 6.12.0"
-      }
-    },
-    "node_modules/@slack/bolt/node_modules/@slack/web-api/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@slack/bolt/node_modules/@slack/web-api/node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@slack/bolt/node_modules/p-queue": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "dependencies": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@slack/bolt/node_modules/p-queue/node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
     "node_modules/@slack/deno-slack-sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@slack/deno-slack-sdk/-/deno-slack-sdk-1.2.0.tgz",
-      "integrity": "sha512-8jgdl8BmccDj35OChtDf1yK3TBqSZ/pzCT/+b6vI+tRlUWkqe/hH9ZFHyyLsYl4QtjmZpWBru0oMG2npaywtzw==",
-      "dependencies": {
-        "@deno/shim-deno": "~0.10.0",
-        "node-fetch": "2.6.7"
-      },
-      "engines": {
-        "node": ">=14.20.1",
-        "npm": ">=6.14.15"
-      }
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@slack/deno-slack-sdk/-/deno-slack-sdk-1.1.2.tgz",
+      "integrity": "sha512-vkaOQKYO6eGZgIhA8MD9j5HdDDWSIL/Gs6HOMA29MwoDWzG1432teFm56mqxnnKCvU6idmIBey45af8K8Gf2pg=="
     },
     "node_modules/@slack/logger": {
       "version": "3.0.0",
@@ -945,9 +858,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
       "engines": {
         "node": ">=12"
       }
@@ -1075,13 +988,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
+      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.2",
-        "@humanwhocodes/config-array": "^0.10.5",
+        "@eslint/eslintrc": "^1.3.1",
+        "@humanwhocodes/config-array": "^0.10.4",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
@@ -1099,6 +1012,7 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
+        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -1107,7 +1021,6 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -1653,6 +1566,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
+    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -2157,7 +2076,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/iterate-iterator": {
       "version": "1.0.2",
@@ -2178,12 +2098,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/js-sdsl": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -2446,25 +2360,6 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/object-inspect": {
@@ -3205,11 +3100,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -3313,24 +3203,11 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3405,24 +3282,10 @@
     }
   },
   "dependencies": {
-    "@deno/shim-deno": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.10.0.tgz",
-      "integrity": "sha512-E7rQ0Hk33V45xQXKEnCxizdSP5C+hhqw1H3xWXsct3kYFWgG93B5gN3LKlyvcxbckt8d67jVa6s+y5duRYawvg==",
-      "requires": {
-        "@deno/shim-deno-test": "^0.3.2",
-        "which": "^2.0.2"
-      }
-    },
-    "@deno/shim-deno-test": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.3.3.tgz",
-      "integrity": "sha512-Ge0Tnl7zZY0VvEfgsyLhjid8DzI1d0La0dgm+3m0/A8gZXgp5xwlyIyue5e4SCUuVB/3AH/0lun9LcJhhTwmbg=="
-    },
     "@eslint/eslintrc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
+      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -3437,9 +3300,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -3492,16 +3355,16 @@
       }
     },
     "@slack/bolt": {
-      "version": "4.0.0-nextGen.6",
-      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.0.0-nextGen.6.tgz",
-      "integrity": "sha512-mQyrLXd8OBYhJm9YTJi4OG7fL5XGsgTn1wbc25vTBONGkUS01lNk2rlryI2U7JuTv1MXd9GQju1vn8UoTqZpmw==",
+      "version": "4.0.0-nextGen.2",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.0.0-nextGen.2.tgz",
+      "integrity": "sha512-aenyxrYo2vrshN3sn5v1uuy9j7LuJKwFj1ofWHnSMJbH+PwSqzxDJJiXNju+7rRMuZs6S8YFt9WH+SdYL7piWw==",
       "requires": {
         "@slack/deno-slack-sdk": "^1.0.0",
         "@slack/logger": "^3.0.0",
         "@slack/oauth": "^2.5.1",
         "@slack/socket-mode": "^1.3.0",
         "@slack/types": "^2.7.0",
-        "@slack/web-api": "6.7.2-nextGen.1",
+        "@slack/web-api": "^6.7.1",
         "@types/express": "^4.16.1",
         "@types/node": "18.7.15",
         "@types/promise.allsettled": "^1.0.3",
@@ -3514,75 +3377,12 @@
         "promise.allsettled": "^1.0.2",
         "raw-body": "^2.3.3",
         "tsscmp": "^1.0.6"
-      },
-      "dependencies": {
-        "@slack/web-api": {
-          "version": "6.7.2-nextGen.1",
-          "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.7.2-nextGen.1.tgz",
-          "integrity": "sha512-7F3P7l23nIadgioeGe/Hwfnttqejz5XMvQuzkPE2A903tUIr6VGin2UMoXiLPmCoQ1UZiPU8/0bHmFJhN+vmdw==",
-          "requires": {
-            "@slack/logger": "^3.0.0",
-            "@slack/types": "^2.0.0",
-            "@types/is-stream": "^1.1.0",
-            "@types/node": ">=12.0.0",
-            "axios": "^0.27.2",
-            "eventemitter3": "^3.1.0",
-            "form-data": "^2.5.0",
-            "is-electron": "2.2.0",
-            "is-stream": "^1.1.0",
-            "p-queue": "^6.6.1",
-            "p-retry": "^4.0.0"
-          },
-          "dependencies": {
-            "axios": {
-              "version": "0.27.2",
-              "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-              "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-              "requires": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
-              },
-              "dependencies": {
-                "form-data": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-                  "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-                  "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.8",
-                    "mime-types": "^2.1.12"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "p-queue": {
-          "version": "6.6.2",
-          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-          "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-          "requires": {
-            "eventemitter3": "^4.0.4",
-            "p-timeout": "^3.2.0"
-          },
-          "dependencies": {
-            "eventemitter3": {
-              "version": "4.0.7",
-              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-              "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-            }
-          }
-        }
       }
     },
     "@slack/deno-slack-sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@slack/deno-slack-sdk/-/deno-slack-sdk-1.2.0.tgz",
-      "integrity": "sha512-8jgdl8BmccDj35OChtDf1yK3TBqSZ/pzCT/+b6vI+tRlUWkqe/hH9ZFHyyLsYl4QtjmZpWBru0oMG2npaywtzw==",
-      "requires": {
-        "@deno/shim-deno": "~0.10.0",
-        "node-fetch": "2.6.7"
-      }
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@slack/deno-slack-sdk/-/deno-slack-sdk-1.1.2.tgz",
+      "integrity": "sha512-vkaOQKYO6eGZgIhA8MD9j5HdDDWSIL/Gs6HOMA29MwoDWzG1432teFm56mqxnnKCvU6idmIBey45af8K8Gf2pg=="
     },
     "@slack/logger": {
       "version": "3.0.0",
@@ -4143,9 +3943,9 @@
       }
     },
     "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -4246,13 +4046,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
+      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.2",
-        "@humanwhocodes/config-array": "^0.10.5",
+        "@eslint/eslintrc": "^1.3.1",
+        "@humanwhocodes/config-array": "^0.10.4",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
@@ -4270,6 +4070,7 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
+        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -4278,7 +4079,6 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -4710,6 +4510,12 @@
         "functions-have-names": "^1.2.2"
       }
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
+    },
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -5049,7 +4855,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "iterate-iterator": {
       "version": "1.0.2",
@@ -5064,12 +4871,6 @@
         "es-get-iterator": "^1.0.2",
         "iterate-iterator": "^1.0.1"
       }
-    },
-    "js-sdsl": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -5283,14 +5084,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -5796,11 +5589,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -5877,24 +5665,11 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   },
   "dependencies": {
     "@slack/bolt": "next-gen",
-    "@slack/deno-slack-sdk": "^1.2.0",
-    "dotenv": "~16.0.3"
+    "@slack/deno-slack-sdk": "^1.1.2",
+    "dotenv": "~16.0.2"
   },
   "devDependencies": {
-    "eslint": "~8.24.0",
+    "eslint": "~8.23.0",
     "eslint-config-airbnb-base": "~15.0.0",
     "eslint-plugin-import": "~2.26.0"
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dotenv": "~16.0.3"
   },
   "devDependencies": {
-    "eslint": "~8.23.0",
+    "eslint": "~8.24.0",
     "eslint-config-airbnb-base": "~15.0.0",
     "eslint-plugin-import": "~2.26.0"
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@slack/bolt": "next-gen",
-    "@slack/deno-slack-sdk": "^1.1.2",
+    "@slack/deno-slack-sdk": "^1.2.0",
     "dotenv": "~16.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@slack/bolt": "next-gen",
     "@slack/deno-slack-sdk": "^1.1.2",
-    "dotenv": "~16.0.2"
+    "dotenv": "~16.0.3"
   },
   "devDependencies": {
     "eslint": "~8.23.0",


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

When upgrading the dependabot dependencies (`eslint`, `@slack-bolt`, `dotenv`, and `deno-slack-sdk`), something ended up breaking and causing an error for `slack create` off this template once all dependency PRs had been merged in:
```
⚠️  Error installing project dependencies: exit status 1
```

I have created this branch, on which I manually reinstalled all upgraded dependencies incrementally like dependabot has, and this is the addition of a new `package-lock.json` that I have confirmed works with `hermes create`. Not sure what went wrong with dependabot, but I suspect it might've been some weirdness with the rebasing that caused conflicts in the `package-lock.json`.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
